### PR TITLE
ability to pass in http:// or https:// protocol

### DIFF
--- a/npm-publish-stream.js
+++ b/npm-publish-stream.js
@@ -6,7 +6,7 @@ const http           = require('http')
     , inherits       = require('util').inherits
 
 function fetch (options, callback) {
-  var url = 'http://'
+  var url = (options.protocol || 'http://')
       + (options.hostname || 'isaacs.iriscouch.com')
       + ':' + (options.port || 80)
       + '/registry/_design/app/_view/updated?include_docs=true&startkey='

--- a/npm-publish-stream.js
+++ b/npm-publish-stream.js
@@ -6,9 +6,9 @@ const http           = require('http')
     , inherits       = require('util').inherits
 
 function fetch (options, callback) {
-  var url = (options.protocol || 'http://')
-      + (options.hostname || 'isaacs.iriscouch.com')
-      + ':' + (options.port || 80)
+  var url = (options.protocol || 'https://')
+      + (options.hostname || 'skimdb.npmjs.com')
+      + ':' + (options.port || 443)
       + '/registry/_design/app/_view/updated?include_docs=true&startkey='
           + JSON.stringify(options.startTime)
 

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ test('simple single scan', function (t) {
     t.like(url, new RegExp('/registry/_design/app/_view/updated\\?include_docs=true\\&startkey=' + time))
   })
   ee.once('ready', function () {
-    var nps = new NpmPublishStream({ hostname: 'localhost', port: PORT })
+    var nps = new NpmPublishStream({ hostname: 'localhost', port: PORT, protocol: 'http://' })
       , i   = 0
 
     nps.on('error', t.fail.bind(t))
@@ -74,7 +74,7 @@ test('simple double scan, same data', function (t) {
     t.like(url, new RegExp('/registry/_design/app/_view/updated\\?include_docs=true\\&startkey=' + time))
   })
   ee.once('ready', function () {
-    var nps = new NpmPublishStream({ hostname: 'localhost', port: PORT, refreshRate: 100 })
+    var nps = new NpmPublishStream({ hostname: 'localhost', port: PORT, refreshRate: 100, protocol: 'http://' })
       , i   = 0
 
     nps.on('error', t.fail.bind(t))
@@ -114,6 +114,7 @@ test('simple multi scan, overlapping & new data', function (t) {
             hostname    : 'localhost'
           , port        : PORT
           , refreshRate : 100
+          , protocol    : 'http://'
           , startTime   : expected[0][0].key
         })
 
@@ -150,6 +151,7 @@ test('simple server down & restart', function (t) {
     nps = new NpmPublishStream({
             hostname : 'localhost'
           , port     : PORT
+          , protocol : 'http://'
           , refreshRate: 100
         })
       , i   = 0


### PR DESCRIPTION
this is part of fixing #2

the new registry endpoints are https only (http://blog.npmjs.org/post/75707294465/new-npm-registry-architecture)

but npm-publish-stream was hardcoded for http before. this makes it option-able
